### PR TITLE
Dev fix tool choice bug

### DIFF
--- a/openAIChat.m
+++ b/openAIChat.m
@@ -311,8 +311,8 @@ classdef(Sealed) openAIChat
                 if ~isempty(this.Tools) 
                     toolChoice = "auto";
                 end
-            elseif ToolChoice ~= "auto"
-                % if toolChoice is not empty, then it must be in the format
+            elseif ~ismember(ToolChoice,["auto","none"])
+                % if toolChoice is not empty, then it must be "auto", "none" or in the format
                 % {"type": "function", "function": {"name": "my_function"}}
                 toolChoice = struct("type","function","function",struct("name",toolChoice));
             end

--- a/openAIChat.m
+++ b/openAIChat.m
@@ -311,7 +311,7 @@ classdef(Sealed) openAIChat
                 if ~isempty(this.Tools) 
                     toolChoice = "auto";
                 end
-            elseif ~ismember(ToolChoice,["auto","none"])
+            elseif ~ismember(toolChoice,["auto","none"])
                 % if toolChoice is not empty, then it must be "auto", "none" or in the format
                 % {"type": "function", "function": {"name": "my_function"}}
                 toolChoice = struct("type","function","function",struct("name",toolChoice));

--- a/tests/topenAIChat.m
+++ b/tests/topenAIChat.m
@@ -77,7 +77,7 @@ classdef topenAIChat < matlab.unittest.TestCase
             testCase.verifyError(@()generate(chat,"input", ToolChoice="bla"), "llms:mustSetFunctionsForCall");
         end
 
-        function errorsWhenPassingToolChoiceWithNone(testCase)
+        function settingToolChoiceWithNone(testCase)
             functions = openAIFunction("funName");
             chat = openAIChat(ApiKey="this-is-not-a-real-key",Tools=functions);
             testCase.verifyWarningFree(@()generate(chat,"This is okay","ToolChoice","none"));

--- a/tests/topenAIChat.m
+++ b/tests/topenAIChat.m
@@ -77,6 +77,12 @@ classdef topenAIChat < matlab.unittest.TestCase
             testCase.verifyError(@()generate(chat,"input", ToolChoice="bla"), "llms:mustSetFunctionsForCall");
         end
 
+        function errorsWhenPassingToolChoiceWithNone(testCase)
+            functions = openAIFunction("funName");
+            chat = openAIChat(ApiKey="this-is-not-a-real-key",Tools=functions);
+            testCase.verifyWarningFree(@()generate(chat,"This is okay","ToolChoice","none"));
+        end
+
         function invalidInputsConstructor(testCase, InvalidConstructorInput)
             testCase.verifyError(@()openAIChat(InvalidConstructorInput.Input{:}), InvalidConstructorInput.Error);
         end


### PR DESCRIPTION
As described in [Issue 11](https://github.com/matlab-deep-learning/llms-with-matlab/issues/11), currently you cannot select "none" in ToolChoice. Fixing this bug with this update. 