### PR TITLE
Update actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,25 @@
 name: Run MATLAB Tests on GitHub-Hosted Runner
 on: [push]
 jobs:
-  my-job:
+  test:
     name: Run MATLAB Tests and Generate Artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          products: Text_Analytics_Toolbox
+          cache: true
       - name: Run tests and generate artifacts
-        uses: matlab-actions/run-tests@v1
+        uses: matlab-actions/run-tests@v2
         with:
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml
           source-folder: .
-      - uses: codecov/codecov-action@v4
-        with:
-          file: coverage.xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: matlab-deep-learning/llms-with-matlab


### PR DESCRIPTION
This change updates the GitHub Actions workflow to use the latest versions of actions. The most relevant being `matlab-actions/setup-matlab@v2` and `matlab-actions/run-tests@v2`. We are working on moving folks off of v1.