### PR TITLE
Replace bakllava by moondream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Pull models
         run: |
             ollama pull mistral
-            ollama pull bakllava
+            ollama pull moondream
             OLLAMA_HOST=127.0.0.1:11435 ollama pull qwen2:0.5b
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2

--- a/tests/tollamaChat.m
+++ b/tests/tollamaChat.m
@@ -99,7 +99,7 @@ classdef tollamaChat < matlab.unittest.TestCase
         end
 
         function generateWithImages(testCase)
-            chat = ollamaChat("bakllava");
+            chat = ollamaChat("moondream");
             image_path = "peppers.png";
             emptyMessages = messageHistory;
             messages = addUserMessageWithImages(emptyMessages,"What is in the image?",image_path);


### PR DESCRIPTION
moondream is a much smaller vision model and perfectly suitable for the tests we want to run.