### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners, to get auto-filled reviewer lists
+
+# To start with, we just assume everyone in the core team is included on all reviews
+* @adulai @ccreutzi @debymf @MiriamScharnke @vpapanasta


### PR DESCRIPTION
One of the steps for having reviewers auto-assigned as discussed.