### PR TITLE
Avoid bogus access to `json.choices.delta.content`

### DIFF
--- a/+llms/+stream/responseStreamer.m
+++ b/+llms/+stream/responseStreamer.m
@@ -84,7 +84,8 @@ classdef responseStreamer < matlab.net.http.io.BinaryConsumer
                                 end
                                 this.StreamFun('');
                                 this.ResponseText = txt;
-                            else
+                            elseif isfield(json.choices,"delta") && ...
+                                    isfield(json.choices.delta,"content")
                                 txt = json.choices.delta.content;
                                 this.StreamFun(txt);
                                 this.ResponseText = [this.ResponseText txt];

--- a/tests/topenAIChat.m
+++ b/tests/topenAIChat.m
@@ -97,6 +97,14 @@ classdef topenAIChat < matlab.unittest.TestCase
             testCase.verifyError(@()openAIChat(InvalidConstructorInput.Input{:}), InvalidConstructorInput.Error);
         end
 
+        function generateWithStreamFunAndMaxNumTokens(testCase)
+            sf = @(x) fprintf("%s",x);
+            chat = openAIChat(StreamFun=sf);
+            result = generate(chat,"Why is a raven like a writing desk?",MaxNumTokens=5);
+            testCase.verifyClass(result,"string");
+            testCase.verifyLessThan(strlength(result), 100);
+        end
+
         function generateWithToolsAndStreamFunc(testCase)
             import matlab.unittest.constraints.HasField
 


### PR DESCRIPTION
The streaming interface sometimes responds with something like `json.choices = {"index":0,"delta":{},"logprobs":[],"finish_reason":"length"}`. Stop blindly assuming `json.choices.delta.content` exists.