### PR TITLE
Use correct `ModelName` default

### DIFF
--- a/openAIChat.m
+++ b/openAIChat.m
@@ -209,7 +209,7 @@ classdef(Sealed) openAIChat < llms.internal.textGenerator & ...
             arguments
                 this                    (1,1) openAIChat
                 messages                      {mustBeValidMsgs}
-                nvp.ModelName           (1,1) string {mustBeModel} = "gpt-4o-mini"
+                nvp.ModelName           (1,1) string {mustBeModel} = this.ModelName
                 nvp.Temperature               {llms.utils.mustBeValidTemperature} = this.Temperature
                 nvp.TopP                      {llms.utils.mustBeValidProbability} = this.TopP
                 nvp.StopSequences             {llms.utils.mustBeValidStop} = this.StopSequences


### PR DESCRIPTION
`openAIChat.generate` needs to use the given `openAIChat`'s model as the default, not a static `gpt-4o-mini"`.

We do not currently have a test seam to verify this default.

Fixes #80.